### PR TITLE
Add end-to-end test for the issuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ npm run start -- dev --config ./examples/git.config.yaml
 npm run start -- deploy --config ./examples/git.config.yaml --service issuer
 ```
 
+* Test end-to-end (only support issuer)
+
+```shell
+npm run start -- test --config ./examples/testE2E.config.yaml --service issuer
+```
+
 ## Config
 
 Example config files are available in [./examples](./examples). You need to place one in the root folder with the name `config.yaml`. For instance, `cp examples/git.config.yaml config.yaml`.

--- a/examples/testE2E.config.yaml
+++ b/examples/testE2E.config.yaml
@@ -1,0 +1,21 @@
+services:
+  attester:
+    url: "https://pp-attester-turnstile.research.cloudflare.com"
+  issuer:
+    git: "git@github.com:cloudflare/privacypass-issuer.git#fab155f47cb14a73678f099a46de40afbc5649a8"
+    port: "8787"
+    test:
+      name: pp-issuer-public.research.cloudflare.com
+      tlsConfig:
+        cert: issuer.crt
+        key: issuer.key
+    deploy:
+      wrangler: "./production.issuer.wrangler.toml"
+      environment: production
+      envFile: .env
+      immediateDeployment: false
+  origin:
+    url: "https://demo-pat.research.cloudflare.com"
+
+config:
+  directory: "dist"


### PR DESCRIPTION
Leverages cloudflare/privacypass-issuer e2e test directly in privacypass-config.

```shell
npm run start -- test --config ./examples/testE2E.config.yaml --service issuer
```

This also provides support for custom TLS configuration, with client side certificate.